### PR TITLE
Include LICENSE in MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include tests/*.py
+include LICENSE


### PR DESCRIPTION
I've put together a build of Flask-Uploads for conda-forge (https://github.com/conda-forge/staged-recipes/pull/1523) It'd be good to include a hard link to the LICENSE file, but doing so requires that the license file be explicitly referenced in the MANIFEST so that it gets bundled in the source distribution.
