### PR TITLE
Add Non-ASCII filename support

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -151,6 +151,18 @@ The field itself should be an ``<input type=file>``.
     </form>
 
 
+Non-ASCII Filename Support
+==========================
+Flask-Uplaods use Werkzeug's ``secure_filename()`` to check filename, it will omit
+Non-ASCII string. When the filename is completely consist of Non-ASCII string, 
+such as Chinese or Japanese, it will return empty filename like ``.jpg``. If your 
+files may encounter a situation like this, you have to set it's name or generate 
+random filename::
+
+    uset.save(file, name='photo_123.')
+    # If name ends with a dot, the file's extension will be appended to the end.
+
+
 API Documentation
 =================
 This documentation is generated directly from the source code.

--- a/flask_uploads.py
+++ b/flask_uploads.py
@@ -79,6 +79,9 @@ def tuple_from(*iters):
 
 def extension(filename):
     ext = os.path.splitext(filename)[1]
+    if ext == '':
+        # add non-ascii filename support
+        ext = os.path.splitext(filename)[0]
     if ext.startswith('.'):
         # os.path.splitext retains . separator
         ext = ext[1:]

--- a/tests.py
+++ b/tests.py
@@ -160,6 +160,15 @@ class TestPreconditions(object):
             tfs = TestingFileStorage(filename=name)
             assert uset.file_allowed(tfs, name) is result
 
+    def test_non_ascii_filename(self):
+        uset = UploadSet('files')
+        uset._config = Config('/uploads')
+        tfs = TestingFileStorage(filename=u'天安门.jpg')
+        res = uset.save(tfs)
+        assert res == 'jpg'
+        res = uset.save(tfs, name='secret.')
+        assert res == 'secret.jpg'
+
     def test_default_extensions(self):
         uset = UploadSet('files')
         uset._config = Config('/uploads')


### PR DESCRIPTION
Make sure the file's extension will be returned. Werkzeug's `secure_filename()` function will return empty when the filename is non-ASCII string.