### PR TITLE
call file_allowed before basename changed

### DIFF
--- a/flask_uploads.py
+++ b/flask_uploads.py
@@ -405,14 +405,17 @@ class UploadSet(object):
             folder, name = os.path.split(name)
 
         basename = self.get_basename(storage.filename)
+        
+        if not self.file_allowed(storage, basename):
+            raise UploadNotAllowed()
+        
         if name:
             if name.endswith('.'):
                 basename = name + extension(basename)
             else:
                 basename = name
 
-        if not self.file_allowed(storage, basename):
-            raise UploadNotAllowed()
+
 
         if folder:
             target_folder = os.path.join(self.config.destination, folder)


### PR DESCRIPTION
I think the upload filter file by the origin file name which is uploaded, not the file name we want to save as