### PR TITLE
Fix the installation instructions in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,5 +5,5 @@ Flask-Uploads provides file uploads for Flask.
 ## Installation
 
 ```sh
-pip install flask-uploads
+pip install git+https://github.com/maxcountryman/flask-uploads.git
 ```


### PR DESCRIPTION
I don't really have time to fix https://github.com/maxcountryman/flask-uploads/issues/39

But as @maxcountryman pointed out there, 
> Python tooling generally makes it trivial to install from git directly

This just updates the README installation instructions to install from git directly.
Hopefully, this will encourage users to work with the current release and not request updates to PyPi